### PR TITLE
Add support to return amphtml

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,8 @@ function analyze(url, body, returnSource) {
       title: things.title.replace(RE_BAD_TITLES, '').replace(RE_AMPS, '&'),
       description: things.description ? things.description.replace(RE_BAD_TITLES, '').replace(RE_AMPS, '&') : '',
       image: things.image,
-      amphtml: things.amphtml
+      amphtml: things.amphtml,
+      canonical: things.canonical
     })
   })
   .then(function (results) {
@@ -231,7 +232,8 @@ function gatherMetaData(url, body) {
       title: (title && title.trim()) || 'Untitled',
       image: image,
       description: getSimpleValue('meta[property="og:description"]', 'content'),
-      amphtml: getSimpleValue('link[rel="amphtml"]', 'href')
+      amphtml: getSimpleValue('link[rel="amphtml"]', 'href'),
+      canonical: getSimpleValue('link[rel="canonical"]', 'href')
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -158,7 +158,8 @@ function analyze(url, body, returnSource) {
     return _.merge(results, {
       title: things.title.replace(RE_BAD_TITLES, '').replace(RE_AMPS, '&'),
       description: things.description ? things.description.replace(RE_BAD_TITLES, '').replace(RE_AMPS, '&') : '',
-      image: things.image
+      image: things.image,
+      amphtml: things.amphtml
     })
   })
   .then(function (results) {
@@ -221,10 +222,17 @@ function gatherMetaData(url, body) {
       description = elemContent && elemContent.trim()
     })
 
+    var amphtml
+    cheerioBody.find('link[rel="amphtml"]').each(function (i, elem) {
+      var elemContent = cheerio(elem).attr('href')
+      amphtml = elemContent && elemContent.trim()
+    })
+
     return {
       title: (title && title.trim()) || 'Untitled',
       image: image,
-      description: description
+      description: description,
+      amphtml: amphtml
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var request = require('request')
 var phantomjs = require('phantomjs-prebuilt')
 
 var defaultReqOptions = {
-  timeout: 5000,
+  timeout: 6000,
   maxRedirects: 30,
   userAgent: 'Schenkerianbot/1.0 (+https://github.com/mix/schenkerian)'
 }
@@ -216,23 +216,22 @@ function gatherMetaData(url, body) {
       image = image.replace(RE_AMPS, '&')
     }
 
-    var description
-    cheerioBody.find('meta[property="og:description"]').each(function (i, elem) {
-      var elemContent = cheerio(elem).attr('content')
-      description = elemContent && elemContent.trim()
-    })
+    var getSimpleValue = function(cheerioTagQuery, targetAttribute) {
+      var foundValue
 
-    var amphtml
-    cheerioBody.find('link[rel="amphtml"]').each(function (i, elem) {
-      var elemContent = cheerio(elem).attr('href')
-      amphtml = elemContent && elemContent.trim()
-    })
+      cheerioBody.find(cheerioTagQuery).each(function (i, elem) {
+        var elemContent = cheerio(elem).attr(targetAttribute)
+        foundValue = elemContent && elemContent.trim()
+      })
+
+      return foundValue
+    }
 
     return {
       title: (title && title.trim()) || 'Untitled',
       image: image,
-      description: description,
-      amphtml: amphtml
+      description: getSimpleValue('meta[property="og:description"]', 'content'),
+      amphtml: getSimpleValue('link[rel="amphtml"]', 'href')
     }
   })
 }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -45,17 +45,19 @@ describe('The analyzer', function () {
       expect(response.description).to.equal('Connecting the curious & creative.')
       expect(response.image).to.exist
       expect(response.amphtml).to.not.exist
+      expect(response.canonical).to.not.exist
     })
   })
 
 
 
-  it('should be able to get amphtml', function () {
+  it('should be able to get amphtml and canonical url', function () {
     return subject({
-      url: 'https://techcrunch.com/2016/09/27/uber-otto-freight-services-2017/'
+      url: 'https://techcrunch.com/2016/09/27/uber-otto-freight-services-2017/?utm_source=buffer'
     })
     .then(function (response) {
       expect(response.amphtml).to.equal('https://techcrunch.com/2016/09/27/uber-otto-freight-services-2017/amp/')
+      expect(response.canonical).to.equal('https://techcrunch.com/2016/09/27/uber-otto-freight-services-2017/')
     })
   })
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -44,6 +44,18 @@ describe('The analyzer', function () {
       expect(response.title).to.equal('Discover, collect, and discuss the best of the web')
       expect(response.description).to.equal('Connecting the curious & creative.')
       expect(response.image).to.exist
+      expect(response.amphtml).to.not.exist
+    })
+  })
+
+
+
+  it('should be able to get amphtml', function () {
+    return subject({
+      url: 'https://techcrunch.com/2016/09/27/uber-otto-freight-services-2017/'
+    })
+    .then(function (response) {
+      expect(response.amphtml).to.equal('https://techcrunch.com/2016/09/27/uber-otto-freight-services-2017/amp/')
     })
   })
 


### PR DESCRIPTION
- Looks for `<link rel="amphtml" href="https://juicy.amp.version">` and returns as part of result if found.
- Result does not include `amphtml` otherwise.