### PR TITLE
Fix text retrieval from response in render-chrome

### DIFF
--- a/lib/render-chrome.js
+++ b/lib/render-chrome.js
@@ -67,9 +67,10 @@ module.exports = function (url, options = {}) {
           body
         }
       }
+      const errBody = await response.text()
       _.merge(err, {
         statusCode: response.status(),
-        errBody: response.text()
+        errBody
       })
     }
 


### PR DESCRIPTION
This was causing an unhandled rejection warning in the output if the response failed