### PR TITLE
Add option to ignore https errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ const pdfExtensions = ['pdf']
 const defaultReqOptions = {
   timeout: 6000,
   maxRedirects: 30,
-  userAgent: 'Schenkerianbot/1.0 (+https://github.com/mix/schenkerian)'
+  userAgent: 'Schenkerianbot/1.0 (+https://github.com/mix/schenkerian)',
+  ignoreHTTPSErrors: false
 }
 
 const RE_SPACES = /\s+/g
@@ -52,7 +53,7 @@ module.exports = function (options) {
 function retrieveContent(url, options) {
   const { forceRequest, agent } = options
   let requestOptions = _.defaults(
-    _.pick(options, ['url', 'timeout', 'userAgent', 'jar', 'cookies']),
+    _.pick(options, ['url', 'timeout', 'userAgent', 'jar', 'cookies', 'ignoreHTTPSErrors']),
     defaultReqOptions
   )
 

--- a/lib/render-chrome.js
+++ b/lib/render-chrome.js
@@ -40,9 +40,10 @@ const DEFAULT_CHROMIUM_ARGS = [
  * @returns {PromiseLike<T> | Promise<T>}
  */
 module.exports = function (url, options = {}) {
-  const { cookies, userAgent, timeout, agentOptions } = options
+  const { cookies, userAgent, timeout, agentOptions, ignoreHTTPSErrors } = options
   const socksArgs = hasSocks(agentOptions) ? socksArguments(agentOptions) : []
   return puppeteer.launch({
+    ignoreHTTPSErrors,
     args: DEFAULT_CHROMIUM_ARGS.concat(socksArgs)
   })
   .then(async browser => {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -219,4 +219,14 @@ describe('schenkerian', function () {
       })).to.be.rejectedWith('Navigation Timeout Exceeded: 1ms exceeded')
     })
   })
+
+  it('deals with bad ssl when using ignoreHTTPSErrors', function () {
+    return subject({
+      url: 'https://expired.badssl.com',
+      ignoreHTTPSErrors: true
+    })
+    .then(function (response) {
+      expect(response.url).to.equal('https://expired.badssl.com/')
+    })
+  })
 })


### PR DESCRIPTION
For simplicity, I kept the naming convention for the option the same as what the puppeteer launch option expects.
I also attempted to add a test for a url that has a bad ssl token.
It doesn't appear to make a difference if it's true or not for this url but I did confirm that it is passed through to the puppeteer configuration flows correctly.