### PR TITLE
use networkidle2 in puppeteer waitUntil options

### DIFF
--- a/lib/render-chrome.js
+++ b/lib/render-chrome.js
@@ -53,7 +53,7 @@ module.exports = function (url, options = {}) {
       await page.setCookie(...cookies)
     }
     const response = await page.goto(url, _.merge({
-      waitUntil: 'domcontentloaded',
+      waitUntil: ['domcontentloaded', 'networkidle2'],
       timeout
     }))
     const err = new Error(`Failed to get acceptable response`)

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -24,9 +24,25 @@ describe('schenkerian', function () {
     })
   })
 
+  it('retrieves analyzed from youtu.be where the title fluctuates', function () {
+    return subject({
+      url: 'https://youtu.be/NjAqVWUaGE0',
+      timeout: 30 * 1000
+    })
+    .then(function (response) {
+      const expectedUrl = 'https://www.youtube.com/watch?v=NjAqVWUaGE0'
+      expect(response.url).to.contain(expectedUrl)
+      expect(response.title).to.equal('Anchorman--Outtakes')
+      expect(response.description).to.equal('')
+      expect(response.image).to.exist
+      expect(response.amphtmlUrl).not.to.exist
+    })
+  })
+
   it('resolves webpage with hash fragments', function () {
     return subject({
-      url: 'https://big.dk/#projects-maze'
+      url: 'https://big.dk/#projects-maze',
+      timeout: 30 * 1000
     })
     .then(function (response) {
       expect(response.url).to.equal('https://big.dk/#projects-maze')


### PR DESCRIPTION
sites like Youtube will return the DOM before the page is fully loaded. in the case of YT, the window title changes after the DOM is loaded. this change attempts to wait for this fluctuation to settle before returning

ref: https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagewaitfornavigationoptions